### PR TITLE
Fix typo in `MediaRecorder.onData` handler.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.reactMultimediaCapture = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.reactMultimediaCapture = f()}})(function(){var define,module,exports;return (function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s}return e})()({1:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -148,7 +148,7 @@ var ReactMediaRecorder = function (_Component) {
 
 				mediaRecorder.ondataavailable = function (ev) {
 					if (ev.data && ev.data.size > 0) {
-						_this3.mediaChunk.push(event.data);
+						_this3.mediaChunk.push(ev.data);
 					}
 				};
 

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ class ReactMediaRecorder extends Component {
 
 			mediaRecorder.ondataavailable = (ev) => {
 				if(ev.data && ev.data.size > 0) {
-					this.mediaChunk.push(event.data);
+					this.mediaChunk.push(ev.data);
 				}
 			};
 


### PR DESCRIPTION
Rename `event` variable to `ev` so that it works as intended. By fluke it worked before in browsers which defined [`Window.event`](https://developer.mozilla.org/en-US/docs/Web/API/Window/event) (like Chrome and Internet Explorer) but not it ones which don't (Firefox).

Please let me know if there's anything else you'd like me to change in this PR!

Resolves #3 