### PR TITLE
Made stopStream optional on stop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ class ReactMediaRecorder extends Component {
 
 		this.props.onResume(this.stream);
 	}
-	stop() {
+	stop(stopStream) {
 		if(!this.state.available) return;
 		if(!this.state.permission) {
 			const permissionError = new Error('You already stopped recording.');
@@ -222,7 +222,7 @@ class ReactMediaRecorder extends Component {
 		let blob = new Blob(this.mediaChunk, { type: 'video/webm' });
 		this.props.onStop(blob);
 		
-		this.stopStream();
+		if(stopStream) this.stopStream();
 	}
 	render() {
 		const asked = this.state.asked;


### PR DESCRIPTION
For the same reason that I needed the stream to be passed on init, I don't want the stream to stop when I stop recording. 
I continuously show the stream, independently of recording.

You don't have to add this if you don't want to, but I like to use it this way. 

I didn't have this problem before, because the stream didn't actually stop earlier.