### PR TITLE
fix Firefox audio track cannot be recorded error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,11 @@ class ReactMediaRecorder extends Component {
 	initMediaRecorder() {
 		try {
 			let options = {};
-			let types = ['video/webm;codecs=vp8', 'video/webm', ''];
+			let types = [
+				this.props.contraints.audio ? 'video/webm;codecs=vp8,opus' : 'video/webm;codecs=vp8',
+				'video/webm',
+				''
+			];
 
 			if(this.props.mimeType) types.unshift(this.props.mimeType);
 


### PR DESCRIPTION
Fix for https://github.com/rico345100/react-multimedia-capture/issues/19